### PR TITLE
Update doc for fullpage_default_font_size setting

### DIFF
--- a/plugins/fullpage.md
+++ b/plugins/fullpage.md
@@ -3,7 +3,7 @@ layout: default
 title: Full Page Plugin
 title_nav: Full Page
 description: Edit all document properties such as title, keywords and description.
-keywords: fullpage fullpage_default_doctype fullpage_default_encoding fullpage_default_fontsize fullpage_default_font_family fullpage_default_langcode fullpage_default_title fullpage_default_text_color fullpage_default_xml_pi fullpage_hide_in_source_view
+keywords: fullpage fullpage_default_doctype fullpage_default_encoding fullpage_default_font_size fullpage_default_font_family fullpage_default_langcode fullpage_default_title fullpage_default_text_color fullpage_default_xml_pi fullpage_hide_in_source_view
 controls: toolbar button, menu item
 ---
 
@@ -60,7 +60,7 @@ tinymce.init({
 });
 ```
 
-### `fullpage_default_fontsize`
+### `fullpage_default_font_size`
 
 This option enables you to specify the default font **size** for the `body` element.
 
@@ -72,7 +72,7 @@ This option enables you to specify the default font **size** for the `body` elem
 tinymce.init({
   selector: "textarea",  // change this value according to your HTML
   plugins: "fullpage",
-  fullpage_default_fontsize: "14px"
+  fullpage_default_font_size: "14px"
 });
 ```
 


### PR DESCRIPTION
Update the setting `fullpage_default_font_size` as it now has an underscore.

The parameter can be found on [this line in the plugin source.](https://github.com/tinymce/tinymce/blob/master/src/plugins/fullpage/src/main/js/api/Settings.js#L33)

This would clarify the docs and stop other users from making the same mistake I did.